### PR TITLE
Replace illegal itemtype "#" with BlogPosting

### DIFF
--- a/views/templates/front/posts.tpl
+++ b/views/templates/front/posts.tpl
@@ -54,7 +54,7 @@
 {block name='page_content'}
 		{capture name=path}<a href="{smartblog::GetSmartBlogLink('smartblog')|escape:'htmlall':'UTF-8'}">{l s='All Blog News' mod='smartblog'}</a><span class="navigation-pipe"></span>{$meta_title|escape:'htmlall':'UTF-8'}{/capture}
 		<div id="content" class="block">
-			<div itemtype="#" itemscope="" id="sdsblogArticle" class="blog-post">
+			<div itemtype="http://schema.org/BlogPosting" itemscope="" id="sdsblogArticle" class="blog-post">
 				<div class="title_block">{$meta_title|escape:'htmlall':'UTF-8'}</div>
 				<div class="sdsarticleHeader">
 					<span>


### PR DESCRIPTION
Google is recently getting stricter in its handling of structured data, and it's just flagged `Invalid value in field 'itemtype'` in the Search Console.  I've checked this change against my site and GSC made a strange reply that there was no structured data on the page (which there is), but also did not complain of the previously flagged error.  Please check this change against your own test site and GSC, and also look at the file `views/templates/front/category_loop.tpl` for similarly illegal usage of the `itemtype` attribute.